### PR TITLE
Use fieldcount to reduce allocations

### DIFF
--- a/src/Rematch.jl
+++ b/src/Rematch.jl
@@ -15,7 +15,7 @@ struct MatchFailure
 end
 
 function assert_num_fields(::Type{T}, matched::Integer) where {T}
-    actual = length(fieldnames(T))
+    actual = fieldcount(T)
     @assert actual == matched "Tried to match $matched fields of $actual field struct $T"
 end
 


### PR DESCRIPTION
`fieldnames` returns a tuple of names constructed for each call (despite being immutable)
whereas fieldcount returns an Int.