### PR TITLE
Add support for interpolating values into the pattern

### DIFF
--- a/src/Rematch.jl
+++ b/src/Rematch.jl
@@ -72,6 +72,12 @@ function handle_destruct(value::Symbol, pattern, bound::Set{Symbol}, asserts::Ve
         quote
             $value == $pattern
         end
+    elseif (pattern isa Expr && pattern.head == :$)  # TODO Is there a better `@capture` way to handle this?
+        # interpolated value
+        # TODO Same as above: do we have to be careful about QuoteNode etc?
+        quote
+            $value == $(esc(pattern.args[1]))
+        end
     elseif @capture(pattern, subpattern_Symbol)
         # variable
         # if the pattern doesn't match, we don't want to set the variable

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -280,6 +280,38 @@ end) == ((2,3),3)
 # don't treat infix operators like structs
 @test_throws assertion_error @eval @match a + b = x
 
+# match against interpolated values
+let outer = 2, b = nothing, c = nothing
+    @test (@match [1, $outer] = [1,2]) == [1,2]
+    @test (@match (1, $outer, b..., c) = (1,2,3,4,5)) == (1,2,3,4,5)
+    @test b == (3,4)
+    @test c == 5
+end
+test_interp_pattern = let a=1, b=2, c=3,
+                          arr=[10,20,30], tup=(100,200,300)
+    _t(x) = @match x begin
+        # scalars
+        [$a,$b,$c,out] => out
+        [fronts..., $a,$b,$c, back] => [fronts...,back]
+        # arrays & tuples
+        [fronts..., $arr, back] => [fronts...,back]
+        [fronts..., $tup, back] => [fronts...,back]
+        # complex expressions
+        [$(a+b+c), out] => out
+        # splatting existing values
+        [fronts..., $(arr...), back] => [fronts...,back]
+    end
+end
+# scalars
+@test test_interp_pattern([1,2,3,4]) == 4
+@test test_interp_pattern([4,3,2,1, 1,2,3, 4]) == [4,3,2,1,4]
+# arrays & tuples
+@test test_interp_pattern([0,1, [10,20,30], 2]) == [0,1,2]
+@test test_interp_pattern([0,1, (100,200,300), 2]) == [0,1,2]
+# complex expressions
+@test test_interp_pattern([6,1]) == 1
+# TODO: splatting existing values into pattern
+@test_broken test_interp_pattern([0,1, 10,20,30, 2]) == [0,1,2]
 
 # --- tests from Match.jl ---
 


### PR DESCRIPTION
Added case to `handle_destruct` to match `$a` or `$(f(a))` expressions.

Currently doesn't handle interpolations that themselves contain splats:
```julia
    arr=[1,2,3]; @match [0, $(arr...), 0] = [0,1,2,3,0]
```