### PR TITLE
Whoops: fixed Coverage lines, remove Example.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,6 @@ git:
 
 after_success:
   # push coverage results to Coveralls
-  - julia -e 'if VERSION >= v"0.7.0-" using Pkg end; cd(Pkg.dir("Example")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
+  - julia -e 'if VERSION >= v"0.7.0-" using Pkg end; Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
   # push coverage results to Codecov
-  - julia -e 'if VERSION >= v"0.7.0-" using Pkg end; cd(Pkg.dir("Example")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())';
+  - julia -e 'if VERSION >= v"0.7.0-" using Pkg end; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())';


### PR DESCRIPTION
I accidentally copied _too much_ from the Example.jl repo. Removed the `cd(Pkg.dir("Example"))` line.

Fixes the mistake created in https://github.com/RelationalAI-oss/Rematch.jl/pull/12.