### PR TITLE
Add tests for QuoteNodes; remove TODO about them

### DIFF
--- a/src/Rematch.jl
+++ b/src/Rematch.jl
@@ -68,13 +68,11 @@ function handle_destruct(value::Symbol, pattern, bound::Set{Symbol}, asserts::Ve
            @capture(pattern, _quote_macrocall) ||
            @capture(pattern, Symbol(_))
         # constant
-        # TODO do we have to be careful about QuoteNode etc?
         quote
             $value == $pattern
         end
     elseif (pattern isa Expr && pattern.head == :$)
         # interpolated value
-        # TODO Same as above: do we have to be careful about QuoteNode etc?
         quote
             $value == $(esc(pattern.args[1]))
         end

--- a/test/rematch.jl
+++ b/test/rematch.jl
@@ -110,6 +110,14 @@ end
     @test (@match v"1.2.0" begin
       v"1.2.0" => :ok
     end) == :ok
+
+    # QuoteNodes
+    @test (@match :(:x) begin
+      :(:x) => :ok
+    end) == :ok
+    @test (@match :(:x+:y) begin
+      :(:x + :y) => :ok
+    end) == :ok
 end
 
 @testset "logical expressions with branches" begin


### PR DESCRIPTION
Remove TODO about `QuoteNode`s.

(Also, i learned about QuoteNodes today. TL;DR is i think we can ignore them and treat them just like any other literal:
https://docs.julialang.org/en/v1/manual/metaprogramming/index.html#QuoteNode-1)

Closes https://github.com/RelationalAI-oss/Rematch.jl/issues/13