### PR TITLE
Drop julia 0.6; update minimum julia to 0.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+.DS_Store
+/Manifest.toml
+/dev/
+
 *.jl.cov
 *.jl.*.cov
 *.jl.mem

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,14 @@
-## Documentation: http://docs.travis-ci.com/user/languages/julia/
+# Documentation: http://docs.travis-ci.com/user/languages/julia/
 language: julia
 os:
   - linux
   - osx
 julia:
-  - 0.6
   - 0.7
-  - 1.0
   - nightly
+matrix:
+  allow_failures:
+    - julia: nightly
+  fast_finish: true
 notifications:
   email: false
-git:
-  depth: 99999999
-
-# # Uncomment the following lines to allow failures on nightly julia
-# # (tests will run but not make your overall status red)
-# matrix:
-#   allow_failures:
-#   - julia: nightly
-
-after_success:
-  # push coverage results to Coveralls
-  - julia -e 'if VERSION >= v"0.7.0-" using Pkg end; Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
-  # push coverage results to Codecov
-  - julia -e 'if VERSION >= v"0.7.0-" using Pkg end; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())';

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,17 @@
+name = "Rematch"
+uuid = "2417414a-39c5-4e49-a7ab-44a21ece1d8d"
+authors = ["Nathan Daly"]
+version = "0.3.0"
+
+[deps]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
+MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+
+[compat]
+julia = "0.7, 1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,0 @@
-julia 0.6
-MacroTools 0.4.0
-Compat

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,47 +1,28 @@
+# Documentation: https://github.com/JuliaCI/Appveyor.jl
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
-
-## uncomment the following lines to allow failures on nightly julia
-## (tests will run but not make your overall status red)
-#matrix:
-#  allow_failures:
-#  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-#  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
-
+  - julia_version: 0.7
+  - julia_version: nightly
+platform:
+  - x86
+  - x64
+matrix:
+  allow_failures:
+    - julia_version: nightly
 branches:
   only:
     - master
     - /release-.*/
-
 notifications:
   - provider: Email
     on_build_success: false
     on_build_failure: false
     on_build_status_changed: false
-
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# If there's a newer build queued for the same PR, cancel this one
-  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
-        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
-        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
-        throw "There are newer queued builds for this pull request, failing early." }
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
-
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"Rematch\"); Pkg.build(\"Rematch\")"
-
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 test_script:
-  - C:\projects\julia\bin\julia -e "Pkg.test(\"Rematch\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"


### PR DESCRIPTION
Suggested by @JKRT in #21, dropping julia 0.6 from master. Good suggestion!

Bumps Rematch version to `0.3.0`