### PR TITLE
Extractor functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 /Manifest.toml
 /dev/
+.julia
 
 *.jl.cov
 *.jl.*.cov

--- a/README.md
+++ b/README.md
@@ -127,15 +127,15 @@ For example to destruct an array into its head and tail:
 
 ```julia
 function cons(xs)
-	if isempty(xs)
-		nothing
-	else
-		([xs[1], xs[2:end]])
-	end
+    if isempty(xs)
+        nothing
+    else
+        ([xs[1], xs[2:end]])
+    end
 end
 
 @match [1,2,3] begin
-	cons(x, xs) => @assert x == 1 && xs == [2,3]
+    cons(x, xs) => @assert x == 1 && xs == [2,3]
 end
 ```
 
@@ -143,19 +143,19 @@ Or, here's one that extracts the polar coordinates of a cartesian point:
 
 ```julia
 function polar(p)
-	@match p begin
-		(x, y) =>
-			begin
-				r = sqrt(x^2+y^2)
-				theta = atan(y, x)
-				(r, theta)
-			end
-		_ => nothing
-	end
+    @match p begin
+        (x, y) =>
+            begin
+                r = sqrt(x^2+y^2)
+                theta = atan(y, x)
+                (r, theta)
+            end
+        _ => nothing
+    end
 end
 
 @match (1,1) begin
-	polar(r, theta) => @assert r == sqrt(2) && theta == pi/4
+    polar(r, theta) => @assert r == sqrt(2) && theta == pi/4
 end
 ```
 

--- a/src/Rematch.jl
+++ b/src/Rematch.jl
@@ -129,8 +129,8 @@ function handle_destruct(value::Symbol, pattern, bound::Set{Symbol}, asserts::Ve
         end
     elseif @capture(pattern, T_(subpatterns__))
         # struct or extractor call
-        # structs are uppercase, extractor calls are lowercase
         if !isempty(string(T)) && islowercase(first(string(T)))
+            # Extractor call.
             result = gensym("unapply")
             len = length(subpatterns)
             # Extractor call.
@@ -142,7 +142,7 @@ function handle_destruct(value::Symbol, pattern, bound::Set{Symbol}, asserts::Ve
                     !isnothing($(esc(T))($value))
                 end
             elseif len == 1
-                # If there is one subpattern, the result value is just matched against it.
+                # If there is just one subpattern, the result value is matched against it.
                 quote
                     begin
                         $result = $(esc(T))($value)

--- a/src/Rematch.jl
+++ b/src/Rematch.jl
@@ -134,14 +134,15 @@ function handle_destruct(value::Symbol, pattern, bound::Set{Symbol}, asserts::Ve
             result = gensym("unapply")
             len = length(subpatterns)
             # Extractor call.
-            # The function should take one argument and return either ``nothing`` if the argument does not match
+            # The function should take one argument and return either `nothing`, if the argument does not match,
             # or a tuple if it does match.
-            # If there are no subpatterns, the function should return a boolean.
             if len == 0
+                # If there are no subpatterns, the result value is just checked for nothingness.
                 quote
                     !isnothing($(esc(T))($value))
                 end
             elseif len == 1
+                # If there is one subpattern, the result value is just matched against it.
                 quote
                     begin
                         $result = $(esc(T))($value)
@@ -149,12 +150,13 @@ function handle_destruct(value::Symbol, pattern, bound::Set{Symbol}, asserts::Ve
                     end
                 end
             else
+                # If there is more than one subpattern, the result value is matched against a tuple pattern.
                 quote
                     begin
                         $result = $(esc(T))($value)
                         !isnothing($result) &&
                         ($result isa Tuple) &&
-                        $(handle_destruct_fields(result, pattern, subpatterns, :(length($result)), :getindex, bound, asserts; allow_splat=false))
+                        $(handle_destruct_fields(result, pattern, subpatterns, :(length($result)), :getindex, bound, asserts; allow_splat=true))
                     end
                 end
             end

--- a/src/Rematch.jl
+++ b/src/Rematch.jl
@@ -130,7 +130,7 @@ function handle_destruct(value::Symbol, pattern, bound::Set{Symbol}, asserts::Ve
     elseif @capture(pattern, T_(subpatterns__))
         # struct or extractor call
         # structs are uppercase, extractor calls are lowercase
-        if length(string(T)) > 0 && islowercase(first(string(T)))
+        if !isempty(string(T)) && islowercase(first(string(T)))
             result = gensym("unapply")
             len = length(subpatterns)
             # Extractor call.

--- a/test/rematch.jl
+++ b/test/rematch.jl
@@ -216,7 +216,7 @@ end
 
     @test member(3, insert(3, E()))
 
-    n = 1
+    n = 100
 
     t = E()
     for x in 1:n

--- a/test/rematch.jl
+++ b/test/rematch.jl
@@ -47,6 +47,69 @@ assertion_error = (VERSION >= v"0.7.0-DEV") ? LoadError : AssertionError
     end
 end
 
+@testset "Match using extractors" begin
+    function sub1(x) x+1 end
+
+    # sub1(4) == 3
+    let x = nothing
+        @test (@match 3 begin
+           sub1(x) => x 
+        end) == 4
+
+        @test x == nothing
+    end
+
+    function cons(xs)
+        if isempty(xs)
+            nothing
+        else
+            (xs[1], xs[2:end])
+        end
+    end
+
+    # cons(1, cons(2, (cons(3, []))) == [1,2,3]
+    let a = nothing
+        b = nothing
+        c = nothing
+
+        @test (@match [1,4,9] begin
+           cons(a, cons(b, cons(c, []))) => a + b + c
+        end) == 14
+
+        @test a == nothing
+        @test b == nothing
+        @test c == nothing
+    end
+
+     @match [1,2,3] begin
+         cons(x, xs) =>
+            begin
+                @test x == 1 
+                @test xs == [2,3]
+            end
+     end
+
+     function polar(p)
+         @match p begin
+             (x, y) =>
+                 begin
+                     r = sqrt(x^2+y^2)
+                     theta = atan(y, x)
+                     (r, theta)
+                 end
+             _ => nothing
+         end
+     end
+
+     @match (1,1) begin
+         polar(r, theta) => 
+            begin
+                @test r == sqrt(2)
+                @test theta == pi/4
+            end
+     end
+end
+
 @testset "Match Struct by field names" begin
     # match one struct field by name
     let x = nothing


### PR DESCRIPTION
This PR implements extractor functions for Rematch.

Patterns can use _extractor functions_ (also known as _active patterns_). These are just any function that takes a value to match and returns either `nothing` (indicating match failure) or a tuple that decomposes the value. The tuple is then matched against other patterns. 

An extractor function must have a lowercase name to distinguish it from a struct name. [I'd like to relax this requirement, if possible, but we should discuss.]

An extractor function must take one argument--the value to be matched against--and should return either one value (for nullary and unary patterns), or a tuple of values (for 2+-ary patterns). Returning `nothing` indicates the extractor does not match. 

For example to destruct an array into its head and tail:

```julia
function cons(xs)
    if isempty(xs)
        nothing
    else
        ([xs[1], xs[2:end]])
    end
end

@match [1,2,3] begin
    cons(x, xs) => @assert x == 1 && xs == [2,3]
end
```

The main code changes are in `handle_destruct` for the `T_(subpatterns__)` case.