### PR TITLE
Make MatchFailure a subtype of Exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+**/*~

--- a/src/Rematch.jl
+++ b/src/Rematch.jl
@@ -10,7 +10,7 @@ macro splice(iterator, body)
   Expr(:..., :(($(esc(body)) for $(esc(iterator.args[2])) in $(esc(iterator.args[3])))))
 end
 
-struct MatchFailure
+struct MatchFailure <: Exception
     value
 end
 


### PR DESCRIPTION
The `@match` macro can throw an object of type `MatchFailure`. It'd make sense to let this type be a subtype of `Exception` so that it can be effortlessly caught in `try-catch` expressions.